### PR TITLE
Fix popToTop on Tab pressed

### DIFF
--- a/src/views/TabBarBottom.js
+++ b/src/views/TabBarBottom.js
@@ -11,6 +11,7 @@ import {
   SafeAreaView,
   NavigationActions,
   withOrientation,
+  StackActions,
 } from 'react-navigation';
 
 import TabBarIcon from './TabBarIcon';
@@ -194,7 +195,7 @@ class TabBarBottom extends React.PureComponent {
       let childRoute = navigation.state.routes[index];
       if (childRoute.hasOwnProperty('index') && childRoute.index > 0) {
         navigation.dispatch(
-          NavigationActions.popToTop({ key: childRoute.key })
+          StackActions.popToTop({ key: childRoute.key })
         );
       } else {
         // TODO: do something to scroll to top


### PR DESCRIPTION
Change `NavigationActions.popToTop` to `StackActions.popToTop`.
Before change:
![simulator screen shot - iphone 8 plus - 2018-05-25 at 16 10 06](https://user-images.githubusercontent.com/22102736/40566412-18fc8e68-6036-11e8-9822-61df037a0708.png)
